### PR TITLE
Add support for pulling layer impls from remove git source repos

### DIFF
--- a/vtds_core/private/config/config.yaml
+++ b/vtds_core/private/config/config.yaml
@@ -4,34 +4,31 @@
 # API.
 core:
   # The 'layers' section configures the layer plugins for
-  # loading. There are four layers:
+  # loading. There are four layers plus the vTDS core driver and the
+  # vTDS base library.:
   #
-  # - core
   # - provider
   # - platform
   # - cluster
   # - application
+  # - core
+  # - base
   #
-  # The 'core' layer is a bit special because it specifies the version
-  # of the vTDS core driver that will be used to run vtds
-  # requests. This may differ from the version used to invoke those
+  # The 'core' driver and 'base' library are a bit special because
+  # they specify the the versions of those things used to run vtds
+  # requests. This may differ from the versions used to invoke those
   # requests because vTDS requests run within a run-time created
   # Python virtual environment. The core driver wrapper that initiates
   # requests, however, runs in the user's Python environment using the
   # installed vtds-core package found there. The wrapper, in turn,
-  # creates a virtual environment, installs the core driver and all of
-  # the layers specified here in that virtual environment, then
-  # invokes the requests themselves inside the virtual environment
-  # using the versions specified here..
+  # creates a virtual environment, installs the core driver, base
+  # library and all of the layers specified here in that virtual
+  # environment, then invokes the requests themselves inside the
+  # virtual environment using the versions specified here..
   #
-  # Each layer consists of a pip installable package containing an
-  # importable python module. The installationa and loading is
-  # configured using the following data:
-  #
-  # - index_url
-  #
-  #   the URL to the PyPI style index where the plugin module is
-  #   hosted. If this is empty or null, the public PyPI is used.
+  # Each layer or library consists of a pip installable package
+  # containing an importable python module. The installation and
+  # loading is configured using the following data:
   #
   # - package:
   #
@@ -42,47 +39,94 @@ core:
   #
   #   the module name to be imported from the package -- REQUIRED
   #
+  # - source_type:
+  #
+  #   The type of source from which the package will be pulled. Two
+  #   source types are supported. The default is 'pypi' which is
+  #   treated as a straightforward pip install from the specified PyPI
+  #   index. An optional 'metadata' block for a PyPI source contains
+  #   the following:
+  #
+  # - url
+  #
+  #   the URL to the PyPI style index where the plugin module is
+  #   hosted. If this is empty or null, the public PyPI is used.
+  #
   # - version:
   #
   #   the version requested using the syntax of a pip requirements
   #   file. If this is empty or null, the latest stable version will
   #   be used.
   #
-  # If you are pulling the layer from a private index requiring
+  # If you are pulling the layer from a private PyPIindex requiring
   # access tokens, you will need to provide a means for pip to
   # authenticate. The easiest way to do this is to set up a '.netrc'
   # file for the host in your home directory.
+  #
+  # Alternatively you can use a 'git' source. In this case, the source
+  # is a git repository containing pip installable python source
+  # code. The repository will be cloned and set to the requested
+  # version (branch or tag) then `pip` will be used to install the
+  # package from the cloned git repo. To use a git repo, supply a
+  # 'metadata' block specifying at least the URL of the git repo. As
+  # follows:
+  #
+  # - url:
+  #
+  #   The required URL from which to clone the git repo.
+  #
+  # - version:
+  #
+  #   The optional version (branch, tag or digest). By default the
+  #   default branch is used.
   #
   # The base configuration uses mock implementations of each layer
   # to permit easy unit testing. Override these in your
   # configuration overlay(s) to specify the layer plugins you
   # actually want for your vTDS.
   layers:
+    base:
+      package: vtds-base
+      module: vtds_base
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-base.git"
+        version: null
     core:
-      index_url: "https://artifactory.algol60.net/artifactory/csm-python-modules/simple"
       package: vtds-core
       module: vtds_core
-      version: null
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-core.git"
+        version: null
     provider:
-      index_url: "https://artifactory.algol60.net/artifactory/csm-python-modules/simple"
       package: vtds-provider-mock
       module: vtds_provider_mock
-      version: null
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-provider-mock.git"
+        version: null
     platform:
-      index_url: "https://artifactory.algol60.net/artifactory/csm-python-modules/simple"
       package: vtds-platform-mock
       module: vtds_platform_mock
-      version: null
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-platform-mock.git"
+        version: null
     cluster:
-      index_url: "https://artifactory.algol60.net/artifactory/csm-python-modules/simple"
       package: vtds-cluster-mock
       module: vtds_cluster_mock
-      version: null
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-cluster-mock.git"
+        version: null
     application:
-      index_url: "https://artifactory.algol60.net/artifactory/csm-python-modules/simple"
       package: vtds-application-mock
       module: vtds_application_mock
-      version: null
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-application-mock.git"
+        version: null
 
   # The 'configurations' section lists the configuration overlays to
   # be applied when preparing your vTDS for deployment along with

--- a/vtds_core/private/git_modules.py
+++ b/vtds_core/private/git_modules.py
@@ -20,19 +20,17 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-"""Wrapped dulwich functions for processing git repo configs
+"""Wrapped dulwich functions for processing git repo python modules
 
 """
-from os.path import join as join_path
-from vtds_base import read_config
 from .git_repo import (
     GitRepo,
     GitRepos
 )
 
 
-class GitConfigs(GitRepos):
-    """Container for the list and state of git configuration repos.
+class GitModules(GitRepos):
+    """Container for the list and state of git python module repos.
 
     """
     def __init__(self, build_dir):
@@ -40,9 +38,9 @@ class GitConfigs(GitRepos):
         initialize the list and state of the repos.
 
         """
-        GitRepos.__init__(self, build_dir, "configs")
+        GitRepos.__init__(self, build_dir, "modules")
 
-    def add_config(self, url):
+    def add_module(self, url):
         """Create or learn a directory to contain the repo found at
         the specified URL under the specified build directory tree.
 
@@ -50,33 +48,31 @@ class GitConfigs(GitRepos):
         return self._add_repo(url)
 
 
-class GitConfig(GitRepo):
-    """Configuration from a git repo
+class GitModule(GitRepo):
+    """Python module from a git repo
 
     """
     # Class variable to keep track of the container we are putting all
-    # GitConfig instances into.
-    configs = None
+    # GitModule instances into.
+    modules = None
 
     def __init__(self, url, version, build_dir):
         """Constructor...
 
         """
-        GitConfig.configs = (
-            GitConfigs(build_dir) if GitConfig.configs is None else
-            GitConfig.configs
+        GitModule.modules = (
+            GitModules(build_dir) if GitModule.modules is None else
+            GitModule.modules
         )
-        repo_name, git_dir = GitConfig.configs.add_config(url)
+        repo_name, git_dir = GitModule.modules.add_module(url)
         GitRepo.__init__(self, url, version, repo_name, git_dir)
 
-    def retrieve(self, config_path):
+    def retrieve(self):
         """Retrieve the repo at the specified URL if necessary and
-        return the configuration in the file at the relative path in
-        the repo specified by 'config_path'. The value of 'config_path'
-        is a relative pathname separated by forward slashes ('/').
+        return the path to the directory in the install tree where it
+        is cloned.
 
         """
         self._clone()
         self._get_version()
-        file_path = join_path(self.git_dir, config_path)
-        return read_config(file_path)
+        return self.git_dir

--- a/vtds_core/private/git_repo.py
+++ b/vtds_core/private/git_repo.py
@@ -1,0 +1,254 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Wrapped dulwich functions for processing git repos as vTDS fodder
+
+"""
+from os import makedirs
+from os.path import (
+    join as join_path,
+    exists
+)
+from shutil import rmtree
+from dulwich.porcelain import (
+    clone,
+    checkout_branch
+)
+from dulwich.repo import Repo
+from dulwich.objects import (
+    Tag,
+    Commit
+)
+from vtds_base import (
+    logfile,
+    ContextualError
+)
+
+
+class GitRepos:
+    """Container for the list and state of git repos. The repos are
+    grouped under 'kind' in the build tree.
+
+    """
+    def __init__(self, build_dir, kind):
+        """Constructor: prepare a place for repos to live and
+        initialize the list and state of the repos.
+
+        """
+        self.repos = {}
+        self.repos_dir = join_path(build_dir, "core", kind, "git")
+        if exists(self.repos_dir):
+            try:
+                rmtree(self.repos_dir)
+            except OSError as err:
+                raise ContextualError(
+                    "cannot remove git %s tree '%s' - %s" % (
+                        kind, self.repos_dir, str(err)
+                    )
+                ) from err
+        try:
+            makedirs(self.repos_dir)
+        except OSError as err:
+            raise ContextualError(
+                "cannot create git configs tree '%s' - %s" % (
+                    self.repos_dir, str(err)
+                )
+            ) from err
+
+    def _add_repo(self, url):
+        """Create or learn a directory to contain the repo found at
+        the specified URL under the specified build directory tree.
+
+        """
+        # If we already know the repo, return the path to it
+        if url in self.repos:
+            return self.repos[url]
+        # Don't know it, need to make the dir for it.
+        repo_name = url.split('/')[-1].removesuffix('.git')
+        repo_path = join_path(
+            self.repos_dir, repo_name
+        )
+        self.repos[url] = (repo_name, repo_path)
+        try:
+            makedirs(repo_path)
+        except OSError as err:
+            raise ContextualError(
+                "cannot create git config repo directory '%s' - %s" % (
+                    repo_path, str(err)
+                )
+            ) from err
+        return (repo_name, repo_path)
+
+
+class GitRepo:
+    """Data from a git repo
+
+    """
+    def __init__(self, url, version, repo_name, git_dir):
+        """Constructor...
+
+        """
+        self.url = url
+        self.version = bytes(version, 'UTF-8') if version is not None else None
+        self.default_version = version is None
+        self.repo_name = repo_name
+        self.git_dir = git_dir
+        self.repo = None
+
+    def _clone(self):
+        """Clone the repo that this object refers to.
+
+        """
+        if self.repo is not None:
+            # Already cloned, don't try to do it again
+            return
+        if exists(join_path(self.git_dir, ".git")):
+            # Already cloned but we don't have it loaded yet
+            self.repo = Repo(self.git_dir)
+            return
+        out_log = join_path(self.git_dir, "clone_out.log")
+        # Need to open the log in binary mode because output from
+        # dulwich is done with byte strings.
+        with logfile(out_log, mode='wb', encoding=None) as output:
+            try:
+                clone(self.url, target=self.git_dir, errstream=output)
+            except ContextualError as err:
+                raise ContextualError(
+                    "error cloning GIT configuration repo '%s "
+                    "into directory '%s' - %s" % (
+                        self.url, self.git_dir, str(err)
+                    ),
+                    output=out_log
+                ) from err
+        self.repo = Repo(self.git_dir)
+
+    def _get_object(self, sha):
+        """Given a SHA1 return the object from the repo corresponding
+        to that SHA1.
+
+        """
+        try:
+            return self.repo.get_object(sha)
+        except Exception as err:
+            raise ContextualError(
+                "cannot find the object for SHA1 '%s' in '%s' at '%s'" % (
+                    sha, self.url, self.git_dir
+                )
+            ) from err
+
+    def _commit_from_sha(self, sha):
+        """Deconstruct a tag SHA1 (which could be a Commit or a Tag)
+        and get the commit from it.
+
+        """
+        obj = self._get_object(sha)
+        if not isinstance(obj, (Tag, Commit)):
+            raise ContextualError(
+                "SHA1 '%s' derived from requested version '%s' in '%s' "
+                "at '%s' is neither a Commit nor a Tag" % (
+                    sha, self.version, self.url, self.git_dir
+                )
+            )
+        return sha if not isinstance(obj, Tag) else obj.object[1]
+
+    @staticmethod
+    def _remote_branch(ref):
+        """Based on the name of a ref, determine if it is a remote
+        branch and return True if it is, False if it is not.
+
+        """
+        return ref.startswith(b'refs/remote')
+
+    @staticmethod
+    def _local_branch(ref):
+        """Based on the name of a ref, determine if it is a local
+        branch and return True if it is, False if it is not.
+
+        """
+        return ref.startswith(b'refs/heads')
+
+    @staticmethod
+    def _local_head(ref):
+        """Based on the name of a ref, determine if it is a local
+        branch and return True if it is, False if it is not.
+
+        """
+        return ref == b'HEAD'
+
+    @staticmethod
+    def _tag(ref):
+        """Based on the name of a ref, determine if it is a tag and
+        return True if it is and False if it is not.
+
+        """
+        return ref.startswith(b'refs/tags')
+
+    def _get_version(self):
+        """Check out the branch or tag that the version refers to. If
+        no version, we take the default (do nothing here).
+
+        """
+        if self.default_version or self.version == b"HEAD":
+            # Either no version is known yet for this repo, or the
+            # user requested HEAD (which we interpret at the remote
+            # HEAD since the local HEAD floats). Set the version to
+            # the remote HEAD symref branch.
+            symrefs = self.repo.refs.get_symrefs()
+            self.version = (
+                symrefs[b'refs/remotes/origin/HEAD'].split(b'/')[-1]
+            )
+        true_version = self.version
+        for ref, sha in self.repo.get_refs().items():
+            if self._local_head(ref):
+                # Skip the local HEAD, since that will point to the
+                # most recently selected branch which is useless to
+                # us...
+                continue
+            if ref.split(b'/')[-1] != self.version:
+                # This ref is not our version...
+                continue
+            if self._local_branch(ref):
+                # Already have the local branch
+                true_version = ref
+                break
+            if self._remote_branch(ref):
+                # It's a remote branch, so make a local branch from it
+                true_version = b"refs/heads/%s" % self.version
+                self.repo.refs.add_if_new(true_version, sha)
+                break
+            # We know we matched something, must be a tag: get the
+            # real commit from the tag
+            true_version = self._commit_from_sha(sha)
+            break
+        # Okay, either we matched something above and set things up
+        # the way we want, or the version selected is either a SHA1 or
+        # not a real branch or tag. At this point, it doesn't really
+        # matter. Try to check it out, and if it fails report a
+        # problem.
+        try:
+            checkout_branch(self.repo, true_version)
+        except Exception as err:
+            raise ContextualError(
+                "unable to check-out version '%s' of '%s' in '%s' - %s" % (
+                    self.version, self.url, self.git_dir, str(err)
+                )
+            ) from err

--- a/vtds_core/wrapper.py
+++ b/vtds_core/wrapper.py
@@ -187,7 +187,7 @@ def main(argv):
     venv_path = path_join(
         build_dir, 'core', 'venv'
     ) if venv_path is None else venv_path
-    request_runner = RequestRunner(venv_path, config)
+    request_runner = RequestRunner(venv_path, build_dir, config)
     request = [args[0]]
     request += ['--build-dir=%s' % build_dir]
     request += (


### PR DESCRIPTION
## Summary and Scope

This adds the ability to pull Layer implementations and the base library from remote git repos in addition to the existing ability to pull them from PyPi indices. This is helpful for both development work, where pulling from a branch of a git repo allows testing of code on a branch as it moves forward and for users outside of HPE who do not have access to the private artifactory hosted PyPi index where we currently publish packages for vTDS.

This changes the form of the 'core' configuration so it is not backward compatible with older configs. Otherwise, it is backward compatible code-wise. Canned configurations have been updated to ensure that they work with the new code.

## Issues and Related PRs

* Resolves [VSHA-625](https://jira-pro.it.hpe.com:8443/browse/VSHA-625)

## Testing

Tested by deploying vTDS with both styles of core configuration

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks to this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ N/A ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
