### PR TITLE
Pin Dulwich version to 0.21.x pending fix of Dulwich issue 1389

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ description = 'Core Driver for the Virtual Test Development System (vTDS) suite'
 dependencies = [
     'pyyaml~=6.0',
     'vtds_base~=0.0',
-    'dulwich~=0.21',
+    'dulwich~=0.21.0',
     'requests~=2.31'
 ]
 

--- a/vtds_core/runner.py
+++ b/vtds_core/runner.py
@@ -66,7 +66,7 @@ class RequestRunner:
         self.env_builder = EnvBuilder(
             system_site_packages=False,
             clear=True,
-            symlinks=False,
+            symlinks=True,
             upgrade=False,
             with_pip=False,
             prompt=None,


### PR DESCRIPTION
## Summary and Scope

Dulwich 0.22.3 has a bug in it that is causing it not to clone vtds-configs correctly from github. This has been reported as dulwich issue 1389, which will, hopefully, be resolved. In the meantime, this pins Dulwich to 0.21.x which all work fine.