### PR TITLE
Workaround: force protocol_version=0 in Dulwich clone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ description = 'Core Driver for the Virtual Test Development System (vTDS) suite'
 dependencies = [
     'pyyaml~=6.0',
     'vtds_base~=0.0',
-    'dulwich~=0.21.0',
+    'dulwich~=0.22',
     'requests~=2.31'
 ]
 

--- a/vtds_core/private/git_repo.py
+++ b/vtds_core/private/git_repo.py
@@ -130,7 +130,7 @@ class GitRepo:
         # dulwich is done with byte strings.
         with logfile(out_log, mode='wb', encoding=None) as output:
             try:
-                clone(self.url, target=self.git_dir, errstream=output)
+                clone(self.url, target=self.git_dir, protocol_version=0, errstream=output)
             except ContextualError as err:
                 raise ContextualError(
                     "error cloning GIT configuration repo '%s "


### PR DESCRIPTION
For the time being, force protocol_version=0 in Dulwich clone in order to work around git protocol version 2 updates in Dulwich. There are several aspects of working with refs that are causing regressions for my code in the update but work fine if protocol version is left at version 1 (protocol_version=0). This lets us track newer releases of Dulwich without those regressions. Once the issues have been fixed in Dulwich, I can back this change out.

