### PR TITLE
Remove Dulwich 0.22.3 and 0.22.4 bug workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ description = 'Core Driver for the Virtual Test Development System (vTDS) suite'
 dependencies = [
     'pyyaml~=6.0',
     'vtds_base~=0.0',
-    'dulwich~=0.22',
+    # There was a bug in Dulwich 0.22.3 and 0.22.4 that caused refs not
+    # to be handled properly. Exclude those and got for a 0.22 compatible
+    # version of Dulwich.
+    'dulwich~=0.22,!=0.22.3,!=0.22.4',
     'requests~=2.31'
 ]
 

--- a/vtds_core/private/git_repo.py
+++ b/vtds_core/private/git_repo.py
@@ -130,7 +130,7 @@ class GitRepo:
         # dulwich is done with byte strings.
         with logfile(out_log, mode='wb', encoding=None) as output:
             try:
-                clone(self.url, target=self.git_dir, protocol_version=0, errstream=output)
+                clone(self.url, target=self.git_dir, errstream=output)
             except ContextualError as err:
                 raise ContextualError(
                     "error cloning GIT configuration repo '%s "


### PR DESCRIPTION
Remove the workaround for the ref retrieval problems introduced to Dulwich in 0.22.3 and 0.22.4. Also exclude those two versions from the dependency candidates for installation.
